### PR TITLE
use entity key based on both type and ID in the session identity map

### DIFF
--- a/src/HybridDb.Tests/Bugs/IdentityMapThinksIdsAreGlobal.cs
+++ b/src/HybridDb.Tests/Bugs/IdentityMapThinksIdsAreGlobal.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Xunit;
+
+namespace HybridDb.Tests.Bugs
+{
+    public class IdentityMapThinksIdsAreGlobal : IDisposable
+    {
+        readonly LambdaHybridDbConfigurator configurator = new LambdaHybridDbConfigurator(config =>
+        {
+            config.Document<Doc1>().Key(x => x.Id);
+            config.Document<Doc2>().Key(x => x.Id);
+        });
+
+        readonly IDocumentStore documentStore;
+
+        const string ThisIsAKnownId = "this is a known ID";
+
+        public IdentityMapThinksIdsAreGlobal()
+        {
+            documentStore = DocumentStore.ForTesting(TableMode.UseTempTables, configurator);
+        }
+
+        public void Dispose()
+        {
+            documentStore.Dispose();
+        }
+
+        [Fact]
+        public void DocumentsAreCachedNotOnlyByIdButAlsoByType()
+        {
+            Save(new Doc1 { Id = ThisIsAKnownId, Label = "this is doc1" });
+            Save(new Doc2 { Id = ThisIsAKnownId, Caption = "this is doc2" });
+
+            using (var session = documentStore.OpenSession())
+            {
+                var doc1 = session.Load<Doc1>(ThisIsAKnownId);
+                var doc2 = session.Load<Doc2>(ThisIsAKnownId);
+
+                Assert.Equal("this is doc1", doc1.Label);
+                Assert.Equal("this is doc2", doc2.Caption);
+            }
+        }
+
+        void Save(object doc)
+        {
+            using (var session1 = documentStore.OpenSession())
+            {
+                session1.Store(doc);
+                session1.SaveChanges();
+            }
+        }
+
+        class Doc1
+        {
+            public string Id { get; set; }
+            public string Label { get; set; }
+        }
+
+        class Doc2
+        {
+            public string Id { get; set; }
+            public string Caption { get; set; }
+        }
+    }
+}

--- a/src/HybridDb.Tests/DocumentSessionTests.cs
+++ b/src/HybridDb.Tests/DocumentSessionTests.cs
@@ -21,9 +21,9 @@ namespace HybridDb.Tests
             {
                 var entity1 = new Entity { Id = id, Property = "Asger" };
                 session.Store(entity1);
-                session.Advanced.IsLoaded(id).ShouldBe(true);
+                session.Advanced.IsLoaded<Entity>(id).ShouldBe(true);
                 session.Advanced.Evict(entity1);
-                session.Advanced.IsLoaded(id).ShouldBe(false);
+                session.Advanced.IsLoaded<Entity>(id).ShouldBe(false);
             }
         }
 
@@ -39,7 +39,7 @@ namespace HybridDb.Tests
 
                 session.Store(entity1);
                 session.Advanced.GetEtagFor(entity1).ShouldBe(Guid.Empty);
-                
+
                 session.SaveChanges();
                 session.Advanced.GetEtagFor(entity1).ShouldNotBe(null);
                 session.Advanced.GetEtagFor(entity1).ShouldNotBe(Guid.Empty);
@@ -58,7 +58,7 @@ namespace HybridDb.Tests
                 // the initial migrations might issue some requests
                 var initialNumberOfRequest = store.NumberOfRequests;
 
-                session.Advanced.Defer(new InsertCommand(table.Table, id, new{}));
+                session.Advanced.Defer(new InsertCommand(table.Table, id, new { }));
                 store.NumberOfRequests.ShouldBe(initialNumberOfRequest + 0);
                 session.SaveChanges();
                 store.NumberOfRequests.ShouldBe(initialNumberOfRequest + 1);
@@ -148,8 +148,8 @@ namespace HybridDb.Tests
             var id = NewId();
             using (var session = store.OpenSession())
             {
-                var entity1 = new Entity {Id = id, Property = "Asger"};
-                var entity2 = new Entity {Id = id, Property = "Asger"};
+                var entity1 = new Entity { Id = id, Property = "Asger" };
+                var entity2 = new Entity { Id = id, Property = "Asger" };
                 session.Store(entity1);
                 session.Store(entity2);
                 session.Load<Entity>(id).ShouldBe(entity1);
@@ -164,7 +164,7 @@ namespace HybridDb.Tests
             var id = NewId();
             using (var session = store.OpenSession())
             {
-                var entity = new Entity {Id = id, Property = "Asger"};
+                var entity = new Entity { Id = id, Property = "Asger" };
                 session.Store(entity);
                 session.SaveChanges();
                 entity.Property = "Lars";
@@ -227,10 +227,10 @@ namespace HybridDb.Tests
             var id = NewId();
             using (var session = store.OpenSession())
             {
-                var entity = new Entity {Id = id, Property = "Asger"};
+                var entity = new Entity { Id = id, Property = "Asger" };
                 session.Store(entity);
                 session.Delete(entity);
-                session.Advanced.IsLoaded(id).ShouldBe(false);
+                session.Advanced.IsLoaded<Entity>(id).ShouldBe(false);
             }
         }
 
@@ -244,7 +244,7 @@ namespace HybridDb.Tests
             {
                 var entity = new Entity { Id = id, Property = "Asger" };
                 Should.NotThrow(() => session.Delete(entity));
-                session.Advanced.IsLoaded(id).ShouldBe(false);
+                session.Advanced.IsLoaded<Entity>(id).ShouldBe(false);
             }
         }
 
@@ -259,7 +259,7 @@ namespace HybridDb.Tests
                 session.Store(new Entity { Id = id, Property = "Asger" });
                 session.SaveChanges();
                 session.Advanced.Clear();
-                
+
                 var entity = session.Load<Entity>(id);
                 session.Delete(entity);
                 session.Load<Entity>(id).ShouldBe(null);
@@ -291,7 +291,7 @@ namespace HybridDb.Tests
             {
                 session.Store(new Entity { Id = id, Property = "Asger" });
                 session.Advanced.Clear();
-                session.Advanced.IsLoaded(id).ShouldBe(false);
+                session.Advanced.IsLoaded<Entity>(id).ShouldBe(false);
             }
         }
 
@@ -303,9 +303,9 @@ namespace HybridDb.Tests
             var id = NewId();
             using (var session = store.OpenSession())
             {
-                session.Advanced.IsLoaded(id).ShouldBe(false);
+                session.Advanced.IsLoaded<Entity>(id).ShouldBe(false);
                 session.Store(new Entity { Id = id, Property = "Asger" });
-                session.Advanced.IsLoaded(id).ShouldBe(true);
+                session.Advanced.IsLoaded<Entity>(id).ShouldBe(true);
             }
         }
 
@@ -339,7 +339,7 @@ namespace HybridDb.Tests
                 session.Advanced.Clear();
 
                 var entity = session.Load(store.Configuration.GetDesignFor<Entity>(), id);
-                
+
                 entity.ShouldBeOfType<Entity>();
             }
         }
@@ -370,7 +370,7 @@ namespace HybridDb.Tests
             var id = NewId();
             using (var session = store.OpenSession())
             {
-                var entity = new Entity {Id = id, Property = "Asger"};
+                var entity = new Entity { Id = id, Property = "Asger" };
                 session.Store(entity);
                 session.Load<Entity>(id).ShouldBe(entity);
             }
@@ -531,13 +531,13 @@ namespace HybridDb.Tests
             var id = NewId();
             using (var session = store.OpenSession())
             {
-                session.Store(new Entity { Id = id, Property = "Asger", ProjectedProperty = "Large"});
+                session.Store(new Entity { Id = id, Property = "Asger", ProjectedProperty = "Large" });
                 session.Store(new Entity { Id = id, Property = "Lars", ProjectedProperty = "Small" });
                 session.SaveChanges();
                 session.Advanced.Clear();
 
                 var entities = session.Query<Entity>().Where(x => x.ProjectedProperty == "Large").ToList();
-                
+
                 entities.Count.ShouldBe(1);
                 entities[0].Property.ShouldBe("Asger");
                 entities[0].ProjectedProperty.ShouldBe("Large");
@@ -552,7 +552,7 @@ namespace HybridDb.Tests
             var id = NewId();
             using (var session = store.OpenSession())
             {
-                session.Store(new Entity { Id = id, Property = "Asger", ProjectedProperty = "Large"});
+                session.Store(new Entity { Id = id, Property = "Asger", ProjectedProperty = "Large" });
                 session.SaveChanges();
                 session.Advanced.Clear();
 
@@ -574,7 +574,7 @@ namespace HybridDb.Tests
             var id = NewId();
             using (var session = store.OpenSession())
             {
-                session.Store(new Entity { Id = id, Property = "Asger", ProjectedProperty = "Large"});
+                session.Store(new Entity { Id = id, Property = "Asger", ProjectedProperty = "Large" });
                 session.SaveChanges();
                 session.Advanced.Clear();
 
@@ -593,7 +593,7 @@ namespace HybridDb.Tests
             var id = NewId();
             using (var session = store.OpenSession())
             {
-                session.Store(new Entity { Id = id, Property = "Asger", ProjectedProperty = "Large"});
+                session.Store(new Entity { Id = id, Property = "Asger", ProjectedProperty = "Large" });
                 session.SaveChanges();
                 session.Advanced.Clear();
 
@@ -639,7 +639,7 @@ namespace HybridDb.Tests
             var id = NewId();
             using (var session = store.OpenSession())
             {
-                session.Store(new Entity {Id = id, Property = "Asger", ProjectedProperty = "Large"});
+                session.Store(new Entity { Id = id, Property = "Asger", ProjectedProperty = "Large" });
                 session.SaveChanges();
                 session.Advanced.Clear();
 
@@ -978,7 +978,7 @@ namespace HybridDb.Tests
                 session.SaveChanges();
             }
 
-            (store.NumberOfRequests-numberOfRequests).ShouldBe(1);
+            (store.NumberOfRequests - numberOfRequests).ShouldBe(1);
         }
 
         [Fact]
@@ -1114,8 +1114,8 @@ namespace HybridDb.Tests
                 {
                     session.SaveChanges(); // fails when in an inconsitent state
                 }
-                catch (Exception){}
-                
+                catch (Exception) { }
+
                 Should.Throw<InvalidOperationException>(() => session.SaveChanges())
                     .Message.ShouldBe("Session is not in a valid state. Please dispose it and open a new one.");
             }
@@ -1159,7 +1159,7 @@ namespace HybridDb.Tests
             using (var session = store.OpenSession())
             {
                 var entity = session.Load<Entity>("TheId");
-                
+
                 entity.ShouldNotBe(null);
             }
         }
@@ -1269,7 +1269,7 @@ namespace HybridDb.Tests
                 var entity = session.Load<Entity>(id);
                 session.Advanced.SetMetadataFor(entity, new Dictionary<string, List<string>>
                 {
-                    ["another-key"] = new List<string> {"value"}
+                    ["another-key"] = new List<string> { "value" }
                 });
                 session.SaveChanges();
             }
@@ -1281,7 +1281,7 @@ namespace HybridDb.Tests
                 var metadata = session.Advanced.GetMetadataFor(entity);
 
                 metadata.Keys.Count.ShouldBe(1);
-                metadata["another-key"].ShouldBe(new List<string> { "value"});
+                metadata["another-key"].ShouldBe(new List<string> { "value" });
             }
         }
 

--- a/src/HybridDb.Tests/HybridDb.Tests.csproj
+++ b/src/HybridDb.Tests/HybridDb.Tests.csproj
@@ -77,6 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Bugs\FailsOnNullSafeAccessToNonNullableProperty.cs" />
+    <Compile Include="Bugs\IdentityMapThinksIdsAreGlobal.cs" />
     <Compile Include="Bugs\NotGeneratingNullableColumnsForMethodReturningValueTypes.cs" />
     <Compile Include="ConfigurationTests.cs" />
     <Compile Include="Bugs\NotGeneratingNullableColumnsForNullableTypes.cs" />

--- a/src/HybridDb/EntityKey.cs
+++ b/src/HybridDb/EntityKey.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace HybridDb
+{
+    /// <summary>
+    /// Represents a global identification of a document consisting of both type and ID
+    /// </summary>
+    class EntityKey
+    {
+        public EntityKey(Type type, string id)
+        {
+            Type = type;
+            Id = id;
+        }
+
+        public Type Type { get; private set; }
+        public string Id { get; private set; }
+
+        protected bool Equals(EntityKey other)
+        {
+            return Equals(Type, other.Type) && string.Equals(Id, other.Id);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((EntityKey) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Type != null ? Type.GetHashCode() : 0)*397) ^ (Id != null ? Id.GetHashCode() : 0);
+            }
+        }
+    }
+}

--- a/src/HybridDb/HybridDb.csproj
+++ b/src/HybridDb/HybridDb.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Config\SqlColumn.cs" />
     <Compile Include="Config\SqlTypeMap.cs" />
     <Compile Include="DocumentStoreExtensions.cs" />
+    <Compile Include="EntityKey.cs" />
     <Compile Include="EntityState.cs" />
     <Compile Include="HybridDbConfigurator.cs" />
     <Compile Include="IDatabase.cs" />

--- a/src/HybridDb/IAdvancedDocumentSessionCommands.cs
+++ b/src/HybridDb/IAdvancedDocumentSessionCommands.cs
@@ -7,7 +7,7 @@ namespace HybridDb
     public interface IAdvancedDocumentSessionCommands
     {
         void Clear();
-        bool IsLoaded(string key);
+        bool IsLoaded<T>(string key);
         IDocumentStore DocumentStore { get; }
         void Defer(DatabaseCommand command);
         void Evict(object entity);

--- a/src/HybridDb/IDocumentSession.cs
+++ b/src/HybridDb/IDocumentSession.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using HybridDb.Config;
 


### PR DESCRIPTION
Added a test case to verify the presence of the bug: `IdentityMapThinksIdsAreGlobal`

`DocumentSession` now tracks entities based on the new `EntityKey` type consisting of both the `Type` and the ID of the document.

Had to change the signature of the `IsLoaded` method on `IAdvancedDocumentSessionCommands` to accept the document type as a type argument: `bool IsLoaded<T>(string key)`