### PR TITLE
Use explicit schema migration + longer timeout

### DIFF
--- a/src/HybridDb/Migrations/Schema/Commands/AddColumn.cs
+++ b/src/HybridDb/Migrations/Schema/Commands/AddColumn.cs
@@ -18,12 +18,13 @@ namespace HybridDb.Migrations.Schema.Commands
 
         public override string ToString() => $"Add column {Column} to table {Tablename}.";
 
-        public override void Execute(DocumentStore store)
-        {
-            store.Database.RawExecute(new SqlBuilder()
-                .Append($"alter table {store.Database.FormatTableNameAndEscape(Tablename)} add {store.Database.Escape(Column.Name)}")
-                .Append(DdlCommandEx.BuildColumnSql(Column))
-                .ToString());
-        }
+        public override void Execute(DocumentStore store) =>
+            store.Database.RawExecute(
+                new SqlBuilder()
+                    .Append($"alter table {store.Database.FormatTableNameAndEscape(Tablename)} add {store.Database.Escape(Column.Name)}")
+                    .Append(DdlCommandEx.BuildColumnSql(Column))
+                    .ToString(),
+                schema: true,
+                commandTimeout: 300);
     }
 }


### PR DESCRIPTION
Use explicit schema migration and longer timeout when adding columns in migrations.